### PR TITLE
fixed layer order if squadrats plugin is present

### DIFF
--- a/fix-mapbox.js
+++ b/fix-mapbox.js
@@ -248,6 +248,7 @@ document.arrive(".mapboxgl-map", {onceOnly: false, existing: true, fireOnAttribu
 			if (t) {
 				clearCompositeLayers(map);
 				layerFromLeaflet(map, t,
+							map.getLayer("squadrats-squadrats") ? "squadrats-squadrats" :
 					map.getLayer("global-heatmap") ? "global-heatmap" :
 					map.getLayer("personal-heatmap") ? "personal-heatmap" :
 					"z-index-1");


### PR DESCRIPTION
When the Squadrats plugin is installed, it adds its own Mapbox layers that interfere with the existing layer ordering logic, affecting the visual display of elements. I added a check for the "squadrats-squadrats" layer and use it as the reference when available.